### PR TITLE
正規化モードを `INDEX_STORE_NORMALIZED=1` に依存させ、未設定時は `exact` へフォールバックして警告を出力

### DIFF
--- a/.env.example.txt
+++ b/.env.example.txt
@@ -1,5 +1,5 @@
-## System Version: 1.1.0
-## File Version: 1.2.0
+## System Version: 1.1.2
+## File Version: 1.2.1
 
 SEARCH_FOLDERS="規程=/absolute/path/to/folder1,議事録=/absolute/path/to/folder2"
 
@@ -27,6 +27,12 @@ SEARCH_FOLDERS="規程=/absolute/path/to/folder1,議事録=/absolute/path/to/fol
 
 # processモードで共有メモリ(mmap)を使うか（デフォルト: 1）
 # SEARCH_PROCESS_SHARED=1
+
+# クエリ正規化（off / nfkc_casefold）
+# QUERY_NORMALIZE=off
+
+# 正規化済みテキストをメモリに保持（0=保持しない, 1=保持）
+# INDEX_STORE_NORMALIZED=1
 
 # クエリ統計の保持期間（日）
 # QUERY_STATS_TTL_DAYS=30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # 変更履歴
 
-System Version: 1.1.1
+System Version: 1.1.3
+
+## 1.1.3
+
+- 2026-01-10: 改善: 正規化モードは `INDEX_STORE_NORMALIZED=1` の場合のみ有効化するように調整。
+  - 無効時は `exact` へフォールバックし、警告ログを出力
+
+## 1.1.2
+
+- 2026-01-10: 機能追加: あいまい検索オプション（NFKC + casefold 正規化）を追加（issue #6 対応）。
+  - `normalize_mode` による正規化検索（exact / normalized）をAPIに追加
+  - `QUERY_NORMALIZE` と `INDEX_STORE_NORMALIZED` の設定を追加
+  - 正規化済みテキストの保持に対応し、キャッシュキーにも正規化モードを反映
+  - UIに正規化モードの選択を追加（検索履歴/エクスポートにも反映）
 
 ## 1.1.1
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <!-- System Version: 1.1.1 | File Version: 1.1.6 -->
+  <!-- System Version: 1.1.2 | File Version: 1.1.7 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>フォルダ内テキスト検索</title>
@@ -111,6 +111,14 @@
                 <option value="all">すべて</option>
               </select>
               <span class="hint">検索にのみ適用</span>
+            </div>
+            <div class="form-group compact">
+              <label for="normalizeMode">正規化</label>
+              <select id="normalizeMode" class="input-sm select-sm">
+                <option value="exact" selected>完全一致</option>
+                <option value="normalized">NFKC+casefold</option>
+              </select>
+              <span class="hint">表記ゆれを吸収</span>
             </div>
           </div>
 

--- a/web_server.py
+++ b/web_server.py
@@ -21,8 +21,8 @@ from typing import Dict, List, Tuple
 
 from dotenv import load_dotenv
 
-SYSTEM_VERSION = "1.1.1"
-# File Version: 1.5.5
+SYSTEM_VERSION = "1.1.3"
+# File Version: 1.6.1
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -128,6 +128,20 @@ def normalize_text(text: str) -> str:
     text = text.lower()
     text = re.sub(r"[\n\t\r]", " ", text)
     text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def normalize_text_nfkc_casefold(text: str, compress_spaces: bool = True) -> str:
+    """NFKC + casefold の正規化."""
+    if not text:
+        return ""
+    text = strip_cid(text)
+    text = unicodedata.normalize("NFKC", text)
+    text = normalize_invisible_separators(text)
+    text = text.casefold()
+    text = re.sub(r"[\n\t\r]", " ", text)
+    if compress_spaces:
+        text = re.sub(r"\s+", " ", text)
     return text
 
 
@@ -621,18 +635,27 @@ def search_text_logic(
     search_mode: str,
     range_limit: int,
     space_mode: str,
+    normalize_mode: str,
 ) -> List[Dict]:
     if not norm_keyword_groups:
         return []
 
     raw_text = entry["raw"]
     raw_for_positions = normalize_invisible_separators(raw_text)
-    if space_mode == "all":
-        norm_text = entry["norm_all"]
-    elif space_mode == "jp":
-        norm_text = entry["norm_jp"]
+    if normalize_mode == "normalized":
+        if space_mode == "all":
+            norm_text = entry.get("norm_cf_all") or entry["norm_all"]
+        elif space_mode == "jp":
+            norm_text = entry.get("norm_cf_jp") or entry["norm_jp"]
+        else:
+            norm_text = entry.get("norm_cf") or entry["norm"]
     else:
-        norm_text = entry["norm"]
+        if space_mode == "all":
+            norm_text = entry["norm_all"]
+        elif space_mode == "jp":
+            norm_text = entry["norm_jp"]
+        else:
+            norm_text = entry["norm"]
     is_match = False
     match_pos = -1
 
@@ -713,6 +736,7 @@ def search_entries_chunk(
     search_mode: str,
     range_limit: int,
     space_mode: str,
+    normalize_mode: str,
 ) -> List[Dict]:
     chunk_results: List[Dict] = []
     for entry in entries:
@@ -723,16 +747,18 @@ def search_entries_chunk(
             search_mode,
             range_limit,
             space_mode,
+            normalize_mode,
         )
         if hit:
             chunk_results.extend(hit)
     return chunk_results
 
 
-def build_query_groups(query: str, space_mode: str) -> Tuple[List[str], List[List[str]]]:
+def build_query_groups(query: str, space_mode: str, normalize_mode: str) -> Tuple[List[str], List[List[str]]]:
     keywords = [k for k in (query or "").split() if k.strip()]
+    normalizer = normalize_text_nfkc_casefold if normalize_mode == "normalized" else normalize_text
     norm_keyword_groups = [
-        [apply_space_mode(normalize_text(k).strip(), space_mode)]
+        [apply_space_mode(normalizer(k).strip(), space_mode)]
         for k in keywords
         if k.strip()
     ]
@@ -785,19 +811,31 @@ def search_text_logic_shared(
     search_mode: str,
     range_limit: int,
     space_mode: str,
+    normalize_mode: str,
 ) -> List[Dict]:
     if not norm_keyword_groups_bytes:
         return []
 
-    if space_mode == "all":
-        norm_start = entry["norm_all_off"]
-        norm_len = entry["norm_all_len"]
-    elif space_mode == "jp":
-        norm_start = entry["norm_jp_off"]
-        norm_len = entry["norm_jp_len"]
+    if normalize_mode == "normalized":
+        if space_mode == "all":
+            norm_start = entry.get("norm_cf_all_off", entry["norm_all_off"])
+            norm_len = entry.get("norm_cf_all_len", entry["norm_all_len"])
+        elif space_mode == "jp":
+            norm_start = entry.get("norm_cf_jp_off", entry["norm_jp_off"])
+            norm_len = entry.get("norm_cf_jp_len", entry["norm_jp_len"])
+        else:
+            norm_start = entry.get("norm_cf_off", entry["norm_off"])
+            norm_len = entry.get("norm_cf_len", entry["norm_len"])
     else:
-        norm_start = entry["norm_off"]
-        norm_len = entry["norm_len"]
+        if space_mode == "all":
+            norm_start = entry["norm_all_off"]
+            norm_len = entry["norm_all_len"]
+        elif space_mode == "jp":
+            norm_start = entry["norm_jp_off"]
+            norm_len = entry["norm_jp_len"]
+        else:
+            norm_start = entry["norm_off"]
+            norm_len = entry["norm_len"]
     norm_end = norm_start + norm_len
 
     is_match = False
@@ -847,6 +885,7 @@ def search_entries_chunk_shared(
     search_mode: str,
     range_limit: int,
     space_mode: str,
+    normalize_mode: str,
 ) -> List[Dict]:
     chunk_results: List[Dict] = []
     for entry in entries:
@@ -859,6 +898,7 @@ def search_entries_chunk_shared(
             search_mode,
             range_limit,
             space_mode,
+            normalize_mode,
         )
         if hit:
             chunk_results.extend(hit)
@@ -904,6 +944,7 @@ def perform_search(
                         params.mode,
                         params.range_limit,
                         params.space_mode,
+                        params.normalize_mode,
                     )
                     for chunk in chunks
                 ]
@@ -922,6 +963,7 @@ def perform_search(
                 params.mode,
                 params.range_limit,
                 params.space_mode,
+                params.normalize_mode,
             )
         if os.getenv("SEARCH_DEBUG", "").strip().lower() in {"1", "true", "yes"}:
             log_info(
@@ -1028,6 +1070,7 @@ def perform_search_process(
                         params.mode,
                         params.range_limit,
                         params.space_mode,
+                        params.normalize_mode,
                     )
                     for chunk in chunks
                 ]
@@ -1046,6 +1089,7 @@ def perform_search_process(
                 params.mode,
                 params.range_limit,
                 params.space_mode,
+                params.normalize_mode,
             )
         return folder_results
 
@@ -1097,6 +1141,7 @@ def perform_search_process_shared(
                         params.mode,
                         params.range_limit,
                         params.space_mode,
+                        params.normalize_mode,
                     )
                     for chunk in chunks
                 ]
@@ -1117,6 +1162,7 @@ def perform_search_process_shared(
                 params.mode,
                 params.range_limit,
                 params.space_mode,
+                params.normalize_mode,
             )
         return folder_results
 
@@ -1135,7 +1181,11 @@ def run_search_direct(
     params: "SearchParams",
     target_ids: List[str],
 ) -> Tuple[List[Dict], List[str]]:
-    raw_keywords, norm_keyword_groups = build_query_groups(query, params.space_mode)
+    raw_keywords, norm_keyword_groups = build_query_groups(
+        query,
+        params.space_mode,
+        params.normalize_mode,
+    )
     worker_count = search_worker_count
     if search_execution_mode == "process" and search_executor:
         future = search_executor.submit(
@@ -1982,6 +2032,7 @@ def build_index_for_folder(folder: str, previous_failures: Dict[str, str] | None
 
 
 def build_memory_pages(folder_id: str, folder_name: str, cache: Dict[str, Dict]) -> List[Dict]:
+    store_normalized = env_bool("INDEX_STORE_NORMALIZED", True)
     pages: List[Dict] = []
     for path, meta in cache.items():
         file_name = os.path.basename(path)
@@ -1993,25 +2044,36 @@ def build_memory_pages(folder_id: str, folder_name: str, cache: Dict[str, Dict])
             if not raw_text:
                 continue
             norm_base = normalize_text(raw_text)
-            page_display = "-" if not (is_pdf or is_excel) else page_num
-            pages.append(
-                {
-                    "file": file_name,
-                    "path": path,
-                    "displayPath": display_path,
-                    "page": page_display,
-                    "raw": raw_text,
-                    "norm": norm_base,
-                    "norm_jp": apply_space_mode(norm_base, "jp"),
-                    "norm_all": apply_space_mode(norm_base, "all"),
-                    "folderId": folder_id,
-                    "folderName": folder_name,
-                }
+            norm_cf_base = (
+                normalize_text_nfkc_casefold(raw_text) if store_normalized else ""
             )
+            page_display = "-" if not (is_pdf or is_excel) else page_num
+            entry = {
+                "file": file_name,
+                "path": path,
+                "displayPath": display_path,
+                "page": page_display,
+                "raw": raw_text,
+                "norm": norm_base,
+                "norm_jp": apply_space_mode(norm_base, "jp"),
+                "norm_all": apply_space_mode(norm_base, "all"),
+                "folderId": folder_id,
+                "folderName": folder_name,
+            }
+            if store_normalized:
+                entry.update(
+                    {
+                        "norm_cf": norm_cf_base,
+                        "norm_cf_jp": apply_space_mode(norm_cf_base, "jp"),
+                        "norm_cf_all": apply_space_mode(norm_cf_base, "all"),
+                    }
+                )
+            pages.append(entry)
     return pages
 
 
 def build_shared_blob(shared_path: Path, entries: List[Dict]) -> List[Dict]:
+    store_normalized = env_bool("INDEX_STORE_NORMALIZED", True)
     offsets: List[Dict] = []
     total_size = 0
     for entry in entries:
@@ -2019,25 +2081,53 @@ def build_shared_blob(shared_path: Path, entries: List[Dict]) -> List[Dict]:
         norm_b = encode_norm_text(entry["norm"])
         norm_jp_b = encode_norm_text(entry["norm_jp"])
         norm_all_b = encode_norm_text(entry["norm_all"])
+        norm_cf_b = encode_norm_text(entry.get("norm_cf", "")) if store_normalized else b""
+        norm_cf_jp_b = encode_norm_text(entry.get("norm_cf_jp", "")) if store_normalized else b""
+        norm_cf_all_b = encode_norm_text(entry.get("norm_cf_all", "")) if store_normalized else b""
+        entry_offsets = {
+            "file": entry["file"],
+            "path": entry["path"],
+            "displayPath": entry["displayPath"],
+            "page": entry["page"],
+            "folderId": entry["folderId"],
+            "folderName": entry["folderName"],
+            "raw_off": total_size,
+            "raw_len": len(raw_b),
+            "norm_off": total_size + len(raw_b),
+            "norm_len": len(norm_b),
+            "norm_jp_off": total_size + len(raw_b) + len(norm_b),
+            "norm_jp_len": len(norm_jp_b),
+            "norm_all_off": total_size + len(raw_b) + len(norm_b) + len(norm_jp_b),
+            "norm_all_len": len(norm_all_b),
+        }
+        extra_size = 0
+        if store_normalized:
+            entry_offsets.update(
+                {
+                    "norm_cf_off": total_size + len(raw_b) + len(norm_b) + len(norm_jp_b) + len(norm_all_b),
+                    "norm_cf_len": len(norm_cf_b),
+                    "norm_cf_jp_off": total_size
+                    + len(raw_b)
+                    + len(norm_b)
+                    + len(norm_jp_b)
+                    + len(norm_all_b)
+                    + len(norm_cf_b),
+                    "norm_cf_jp_len": len(norm_cf_jp_b),
+                    "norm_cf_all_off": total_size
+                    + len(raw_b)
+                    + len(norm_b)
+                    + len(norm_jp_b)
+                    + len(norm_all_b)
+                    + len(norm_cf_b)
+                    + len(norm_cf_jp_b),
+                    "norm_cf_all_len": len(norm_cf_all_b),
+                }
+            )
+            extra_size = len(norm_cf_b) + len(norm_cf_jp_b) + len(norm_cf_all_b)
         offsets.append(
-            {
-                "file": entry["file"],
-                "path": entry["path"],
-                "displayPath": entry["displayPath"],
-                "page": entry["page"],
-                "folderId": entry["folderId"],
-                "folderName": entry["folderName"],
-                "raw_off": total_size,
-                "raw_len": len(raw_b),
-                "norm_off": total_size + len(raw_b),
-                "norm_len": len(norm_b),
-                "norm_jp_off": total_size + len(raw_b) + len(norm_b),
-                "norm_jp_len": len(norm_jp_b),
-                "norm_all_off": total_size + len(raw_b) + len(norm_b) + len(norm_jp_b),
-                "norm_all_len": len(norm_all_b),
-            }
+            entry_offsets
         )
-        total_size += len(raw_b) + len(norm_b) + len(norm_jp_b) + len(norm_all_b)
+        total_size += len(raw_b) + len(norm_b) + len(norm_jp_b) + len(norm_all_b) + extra_size
 
     with open(shared_path, "wb") as f:
         f.truncate(total_size)
@@ -2046,6 +2136,10 @@ def build_shared_blob(shared_path: Path, entries: List[Dict]) -> List[Dict]:
             f.write(encode_norm_text(entry["norm"]))
             f.write(encode_norm_text(entry["norm_jp"]))
             f.write(encode_norm_text(entry["norm_all"]))
+            if store_normalized:
+                f.write(encode_norm_text(entry.get("norm_cf", "")))
+                f.write(encode_norm_text(entry.get("norm_cf_jp", "")))
+                f.write(encode_norm_text(entry.get("norm_cf_all", "")))
     return offsets
 
 
@@ -2077,6 +2171,7 @@ class SearchRequest(BaseModel):
     mode: str = Field("AND", pattern="^(AND|OR)$")
     range_limit: int = Field(0, ge=0, le=5000)
     space_mode: str = Field("jp", pattern="^(none|jp|all)$")
+    normalize_mode: str | None = Field(None)
     folders: List[str]
 
     @field_validator("query")
@@ -2090,6 +2185,15 @@ class SearchRequest(BaseModel):
         if not v:
             raise ValueError("検索対象フォルダを1つ以上選択してください")
         return v
+
+    @field_validator("normalize_mode")
+    def validate_normalize_mode(cls, v: str | None) -> str | None:
+        if v is None or not str(v).strip():
+            return None
+        mode = str(v).strip().lower()
+        if mode not in {"exact", "normalized"}:
+            raise ValueError("normalize_mode は exact または normalized を指定してください")
+        return mode
 
 
 # --- グローバル状態 ---
@@ -2210,6 +2314,7 @@ search_worker_count = 1
 search_concurrency = 1
 search_executor = None
 search_execution_mode = "thread"
+normalize_mode_warning_emitted = False
 
 
 WORKER_MEMORY_PAGES: Dict[str, List[Dict]] = {}
@@ -2221,6 +2326,7 @@ class SearchParams:
     mode: str
     range_limit: int
     space_mode: str
+    normalize_mode: str
 
 
 class AsyncRWLock:
@@ -2521,6 +2627,37 @@ def env_float(name: str, default: float) -> float:
         return default
 
 
+def env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if raw in {"1", "true", "yes"}:
+        return True
+    if raw in {"0", "false", "no"}:
+        return False
+    return default
+
+
+def resolve_normalize_mode(value: str | None) -> str:
+    global normalize_mode_warning_emitted
+    store_normalized = env_bool("INDEX_STORE_NORMALIZED", True)
+    if value:
+        normalized = value.strip().lower()
+        if normalized in {"exact", "normalized"}:
+            if normalized == "normalized" and not store_normalized:
+                if not normalize_mode_warning_emitted:
+                    log_warn("正規化モードは INDEX_STORE_NORMALIZED=1 が必要なため exact にフォールバックします")
+                    normalize_mode_warning_emitted = True
+                return "exact"
+            return normalized
+    env_value = os.getenv("QUERY_NORMALIZE", "off").strip().lower()
+    if env_value == "nfkc_casefold":
+        if store_normalized:
+            return "normalized"
+        if not normalize_mode_warning_emitted:
+            log_warn("QUERY_NORMALIZE=nfkc_casefold には INDEX_STORE_NORMALIZED=1 が必要です")
+            normalize_mode_warning_emitted = True
+    return "exact"
+
+
 class MemoryCache:
     def __init__(self, max_entries: int, max_bytes: int, max_result_kb: int) -> None:
         self.max_entries = max_entries
@@ -2591,6 +2728,7 @@ def cache_key_for(query: str, params: "SearchParams", target_ids: List[str]) -> 
         "mode": params.mode,
         "range": params.range_limit,
         "space": params.space_mode,
+        "normalize": params.normalize_mode,
         "folders": sorted(target_ids),
     }
     raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
@@ -2839,6 +2977,7 @@ def update_query_stats(
             "mode": params.mode,
             "range": params.range_limit,
             "space": params.space_mode,
+            "normalize": params.normalize_mode,
             "folders": sorted(target_ids),
             "count_total": 0,
             "count_uncached": 0,
@@ -3054,7 +3193,8 @@ def rebuild_fixed_cache():
         target_ids = [fid for fid in entry.get("folders", []) if fid in folder_states and folder_states[fid].get("ready")]
         if not target_ids:
             continue
-        params = SearchParams(entry["mode"], entry["range"], entry["space"])
+        normalize_mode = resolve_normalize_mode(entry.get("normalize"))
+        params = SearchParams(entry["mode"], entry["range"], entry["space"], normalize_mode)
         try:
             results, keywords = run_search_direct(entry["query"], params, target_ids)
         except Exception:
@@ -3084,6 +3224,7 @@ def rebuild_fixed_cache():
             "mode": entry["mode"],
             "range": entry["range"],
             "space": entry["space"],
+            "normalize": normalize_mode,
             "folders": target_ids,
             "index_uuid": current_index_uuid,
             "schema_version": current_schema_version,
@@ -3357,7 +3498,8 @@ async def search(req: SearchRequest):
             if not target_ids:
                 raise HTTPException(status_code=400, detail="有効な検索対象フォルダがありません")
 
-            params = SearchParams(req.mode, req.range_limit, req.space_mode)
+            normalize_mode = resolve_normalize_mode(req.normalize_mode)
+            params = SearchParams(req.mode, req.range_limit, req.space_mode, normalize_mode)
             cache_key = cache_key_for(req.query, params, target_ids)
 
             # キャッシュからの取得を試行
@@ -3368,7 +3510,11 @@ async def search(req: SearchRequest):
             if cached_result:
                 return cached_result
 
-            keywords, norm_keyword_groups = build_query_groups(req.query, req.space_mode)
+            keywords, norm_keyword_groups = build_query_groups(
+                req.query,
+                req.space_mode,
+                normalize_mode,
+            )
             raw_keywords = keywords
             keywords_for_response = keywords
             worker_count = search_worker_count
@@ -3403,7 +3549,7 @@ async def search(req: SearchRequest):
         elapsed = time.time() - start_time
         log_info(
             f"検索完了: folders={len(target_ids)} results={len(results)} "
-            f"mode={req.mode} workers={worker_count} 時間={elapsed:.2f}s"
+            f"mode={req.mode} normalize={normalize_mode} workers={worker_count} 時間={elapsed:.2f}s"
         )
 
         # Get current index UUID
@@ -3462,8 +3608,13 @@ async def export_results(req: SearchRequest, format: str = "csv"):
             if not target_ids:
                 raise HTTPException(status_code=400, detail="有効な検索対象フォルダがありません")
 
-            params = SearchParams(req.mode, req.range_limit, req.space_mode)
-            keywords, norm_keyword_groups = build_query_groups(req.query, req.space_mode)
+            normalize_mode = resolve_normalize_mode(req.normalize_mode)
+            params = SearchParams(req.mode, req.range_limit, req.space_mode, normalize_mode)
+            keywords, norm_keyword_groups = build_query_groups(
+                req.query,
+                req.space_mode,
+                normalize_mode,
+            )
             raw_keywords = keywords
             worker_count = search_worker_count
             loop = asyncio.get_running_loop()
@@ -3499,6 +3650,7 @@ async def export_results(req: SearchRequest, format: str = "csv"):
         "mode": req.mode,
         "range_limit": req.range_limit,
         "space_mode": req.space_mode,
+        "normalize_mode": normalize_mode,
         "folders": target_ids,
         "folder_names": [folder_states[fid]["name"] for fid in target_ids if fid in folder_states],
         "index_uuid": index_uuid,
@@ -3517,6 +3669,7 @@ async def export_results(req: SearchRequest, format: str = "csv"):
         writer.writerow(["# モード", req.mode])
         writer.writerow(["# 範囲", req.range_limit])
         writer.writerow(["# 空白除去", req.space_mode])
+        writer.writerow(["# 正規化", normalize_mode])
         writer.writerow(["# インデックスUUID", index_uuid])
         writer.writerow(["# エクスポート日時", metadata["exported_at"]])
         writer.writerow(["# 検索フォルダ", ", ".join(metadata["folder_names"])])


### PR DESCRIPTION
### Motivation
- ユーザが `normalized` モードを指定した際に、インデックスに正規化済みテキストが存在しないと誤った検索結果になる可能性があるため安全に扱う必要がある。 
- キャッシュやエクスポート、クエリ統計が正規化モードを考慮して一貫した再現性を持つようにするため。 
- フロントエンドで正規化モードを選択できるようにして検索体験を向上させるため。 
- 変更に伴いリリース情報とバージョン表記を更新するため。 

### Description
- `normalize_text_nfkc_casefold` を追加し、`env_bool` と `resolve_normalize_mode` を実装して `normalized` 指定時に `INDEX_STORE_NORMALIZED` が未設定だと一度だけ警告を出して `exact` にフォールバックするようにした。 
- `SearchParams` に `normalize_mode` を追加し、`build_query_groups`、`search_*`/`search_entries_chunk*`、`perform_search` 系の検索フローとキャッシュキー生成 (`cache_key_for`)／クエリ統計 (`update_query_stats`)／エクスポートメタデータへ正規化モードを伝搬するようにした。 
- インデックス構築／共有バイナリで `INDEX_STORE_NORMALIZED=1` のときに `norm_cf*`（NFKC+casefold 正規化）フィールドを保持・書き込み・参照するようにし、共有 mmap のオフセット計算・読み書きも対応させた。 
- UI 側に正規化モードセレクタを追加し (`static/index.html`, `static/app.js`)、検索履歴・エクスポートに `normalize_mode` を反映し、`CHANGELOG.md` とコード内の `SYSTEM_VERSION`/ファイルバージョンを更新した。 

### Testing
- 自動化されたテストは実行していません（`none`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f082441c8330a9e20446590684b7)