### PR TITLE
Add NFKC+casefold 正規化モードとインデックス保存オプション

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # 変更履歴
 
 System Version: 1.1.1
+File Version: 1.1.2
 
 ## 1.1.1
 
+- 2026-01-10: 機能追加: NFKC + casefold の正規化検索モードを追加（issue #6 対応）。
+  - `QUERY_NORMALIZE` / `INDEX_STORE_NORMALIZED` を追加
+  - 表記ゆれ吸収のため `normalize_mode=normalized` を追加
+  - 検索履歴とエクスポートに正規化モードを反映
 - 2026-01-09: 機能追加: UI改善 - クエリ履歴機能を実装（issue #7 対応）。
   - localStorage を使用した検索履歴の保存（上限50件）
   - ピン留め機能により重要な検索を保存可能

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Full-Search-PDFs
 
 System Version: 1.1.1
-README File Version: 1.1.3
+README File Version: 1.1.4
 
 ローカル/社内フォルダ内の PDF/Office 文書を全文検索する FastAPI アプリです。
 UI は `static/` 配下で提供されます。
@@ -13,6 +13,7 @@ UI は `static/` 配下で提供されます。
 - PDF/DOCX/TXT/CSV/XLSX/XLS のテキスト抽出・検索
 - AND/OR + 文字数範囲指定（AND時）
 - 和文のみ空白除去（デフォルト）
+- 表記ゆれ吸収（NFKC + casefold の正規化モード）
 - 結果の無限スクロール（100件ずつレンダリング）
 - SMB/NAS の表示名置換（表示のみ）
 - SSL 起動（証明書を配置すれば自動）
@@ -105,6 +106,12 @@ CACHE_MEM_MAX_RESULT_KB=2000
 
 # 固定キャッシュの圧縮閾値（KB以上はgzip保存）
 CACHE_COMPRESS_MIN_KB=2000
+
+# クエリ正規化モード（off/nfkc_casefold）
+QUERY_NORMALIZE=off
+
+# インデックスに正規化済みテキストを保持（0/1）
+INDEX_STORE_NORMALIZED=1
 
 # インデックス再構築スケジュール（例: 03:00 or 12h）
 REBUILD_SCHEDULE="03:00"

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,7 @@
 /**
  * フォルダ内テキスト検索 — YomiToku Style
  * System Version: 1.1.1
- * File Version: 1.1.9
+ * File Version: 1.2.0
  */
 
 const state = {
@@ -15,6 +15,7 @@ const state = {
   folderListOpen: true,
   isSearching: false,
   spaceMode: 'none',
+  normalizeMode: 'exact',
   renderedCount: 0,
   groupedResults: null,
   isRenderingBatch: false,
@@ -43,6 +44,7 @@ const resultCountEl = $('resultCount');
 const modeGroup = $('modeGroup');
 const rangeInput = $('range');
 const spaceModeSelect = $('spaceMode');
+const normalizeModeSelect = $('normalizeMode');
 const searchForm = $('searchForm');
 const queryInput = $('query');
 const viewToggle = $('viewToggle');
@@ -173,7 +175,7 @@ const saveQueryHistory = () => {
   }
 };
 
-const addToQueryHistory = (query, mode, range, spaceMode, folders, resultCount, indexUuid) => {
+const addToQueryHistory = (query, mode, range, spaceMode, normalizeMode, folders, resultCount, indexUuid) => {
   const timestamp = Date.now();
   const historyItem = {
     id: `${timestamp}-${Math.random().toString(36).substr(2, 9)}`,
@@ -181,6 +183,7 @@ const addToQueryHistory = (query, mode, range, spaceMode, folders, resultCount, 
     mode,
     range_limit: range,
     space_mode: spaceMode,
+    normalize_mode: normalizeMode,
     folders: [...folders],
     result_count: resultCount,
     index_uuid: indexUuid,
@@ -196,6 +199,7 @@ const addToQueryHistory = (query, mode, range, spaceMode, folders, resultCount, 
       item.mode === mode &&
       item.range_limit === range &&
       item.space_mode === spaceMode &&
+      item.normalize_mode === normalizeMode &&
       JSON.stringify(item.folders.sort()) === JSON.stringify([...folders].sort())
     );
   });
@@ -558,6 +562,9 @@ const executeHistorySearch = async (item) => {
   setMode(item.mode);
   rangeInput.value = item.range_limit || 0;
   spaceModeSelect.value = item.space_mode || 'jp';
+  if (normalizeModeSelect) {
+    normalizeModeSelect.value = item.normalize_mode || 'exact';
+  }
 
   // Restore folder selection
   state.selected = new Set(item.folders);
@@ -582,6 +589,10 @@ const renderHistoryList = () => {
       'jp': '和文のみ',
       'all': 'すべて'
     }[item.space_mode] || item.space_mode;
+    const normalizeLabel = {
+      'exact': '完全一致',
+      'normalized': 'NFKC+casefold'
+    }[item.normalize_mode] || item.normalize_mode || '完全一致';
 
     return `
       <div class="history-item ${item.pinned ? 'pinned' : ''}" data-id="${item.id}">
@@ -604,6 +615,7 @@ const renderHistoryList = () => {
           <span class="chip">${item.mode}</span>
           ${item.range_limit > 0 ? `<span class="chip">範囲: ${item.range_limit}</span>` : ''}
           <span class="chip">空白: ${spaceModeLabel}</span>
+          <span class="chip">表記ゆれ: ${normalizeLabel}</span>
           <span class="chip">${item.result_count} 件</span>
           <span class="chip subtle">${formatTimestamp(item.timestamp)}</span>
         </div>
@@ -1094,14 +1106,17 @@ const runSearch = async (evt) => {
   const query = queryInput.value.trim();
   const rangeVal = parseInt(rangeInput.value || '0', 10);
   const spaceMode = spaceModeSelect?.value || 'none';
+  const normalizeMode = normalizeModeSelect?.value || 'exact';
   const payload = {
     query,
     mode: state.mode,
     range_limit: state.mode === 'AND' ? rangeVal : 0,
     space_mode: spaceMode,
+    normalize_mode: normalizeMode,
     folders: Array.from(state.selected),
   };
   state.spaceMode = spaceMode;
+  state.normalizeMode = normalizeMode;
 
   if (!payload.query) {
     alert('キーワードを入力してください');
@@ -1140,6 +1155,7 @@ const runSearch = async (evt) => {
       state.mode,
       rangeVal,
       spaceMode,
+      normalizeMode,
       payload.folders,
       data.count || 0,
       state.currentIndexUuid
@@ -1242,11 +1258,13 @@ if (exportBtn) {
     const query = queryInput.value.trim();
     const rangeVal = parseInt(rangeInput.value || '0', 10);
     const spaceMode = spaceModeSelect?.value || 'jp';
+    const normalizeMode = normalizeModeSelect?.value || 'exact';
     const payload = {
       query,
       mode: state.mode,
       range_limit: state.mode === 'AND' ? rangeVal : 0,
       space_mode: spaceMode,
+      normalize_mode: normalizeMode,
       folders: Array.from(state.selected),
     };
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <!-- System Version: 1.1.1 | File Version: 1.1.6 -->
+  <!-- System Version: 1.1.1 | File Version: 1.1.7 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>フォルダ内テキスト検索</title>
@@ -111,6 +111,14 @@
                 <option value="all">すべて</option>
               </select>
               <span class="hint">検索にのみ適用</span>
+            </div>
+            <div class="form-group compact">
+              <label for="normalizeMode">表記ゆれ</label>
+              <select id="normalizeMode" class="input-sm select-sm">
+                <option value="exact" selected>完全一致</option>
+                <option value="normalized">NFKC + casefold</option>
+              </select>
+              <span class="hint">文字種の差を吸収</span>
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- トークナイズやn-gramを導入せずに、大小文字・全半角などの表記ゆれを吸収する検索モード（NFKC + `casefold`）を追加するため。これにより英字の大小や全角/半角の差を許容する検索が可能になる。 
- クエリ側とインデックス側の両方で扱えるようにし、将来的にインデックス増加を避ける設定切替を可能にするため。 
- 既存の `exact` 挙動を破壊せずにオプションで提供することを目的とする。

### Description
- 正規化ロジックを追加して `NFKC + casefold` を実装し、`normalize_text_casefold`、`normalize_query_text`、`query_normalize_mode`、`should_store_normalized` を導入した。環境変数は `QUERY_NORMALIZE=off|nfkc_casefold` と `INDEX_STORE_NORMALIZED=0|1` で制御する。
- API/内部パラメータに `normalize_mode` を追加し、`SearchRequest` と `SearchParams` に `normalize_mode` を含めてキャッシュキー（`cache_key_for`）へ反映させ、検索処理に伝搬するようにした（`norm_cf*` フィールドを使用して切替検索）。
- インデックス構築でオプション的にページ単位の正規化済みテキストを `norm_data` として保存し、`build_memory_pages` と共有 Blob（mmap）に `norm_cf` / `norm_cf_jp` / `norm_cf_all` を追加してプロセスモードでも利用可能にした。
- UI に表記ゆれオプションを追加（`static/index.html` の `normalizeMode` セレクト）し、`static/app.js` を更新して検索ペイロード、履歴、エクスポートに `normalize_mode` を反映、README/CHANGELOG を追記および `web_server.py` のファイルバージョンを更新した。

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f082441c8330a9e20446590684b7)