### PR TITLE
検索結果の detail を遅延取得に変更（/api/detail 追加）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # 変更履歴
 
-System Version: 1.1.6
+System Version: 1.1.7
+
+## 1.1.7
+
+- 2026-01-12: 改善: 検索レスポンスの detail を遅延取得に変更（issue #10 対応）。
+  - `/api/search` は detail を除外し、`detail_key` を返すように変更
+  - `/api/detail` を追加し、GET で detail を取得
+  - UIはカード展開時に detail を取得し、ハイライト表示を維持
+  - 検索キャッシュのスキーマを更新（detail除外）
 
 ## 1.1.6
 


### PR DESCRIPTION
### Motivation
- 検索結果が大量のときにレスポンス JSON が大きくなる問題を軽減するため、初回 `/api/search` レスポンスから `detail` を除外して軽量化する目的です。 
- `detail` はクリック時に遅延取得して表示し、現行のハイライト表示が崩れないようにすることが狙いです。 
- UI 側の描画負荷を下げつつ、エクスポート等の用途では従来通り `detail` を生成できるようにします。 

### Description
- サーバー側で `/api/search` の各ヒットから `detail` を取り除き、代わりに `detail_key`（`file_id`, `page`, `hit_pos`）を返すように変更しました。 
- 新たに `GET /api/detail` エンドポイントを追加し、`file_id`/`page`/`hit_pos` を指定して遅延で `detail` を取得できるように実装しました。 
- ファイルパスの短縮ハッシュ `file_id` と逆引きマップを保持する仕組みを導入し、ページ単位の生テキストをキャッシュ／参照する `detail_lookup` を実装しました。 
- UI (`static/app.js`) を更新してカード展開時に `detail` を非同期取得・ハイライト反映し、検索ごとにクライアント側の `detail` キャッシュを初期化するようにしました。 

### Testing
- サーバーを `SEARCH_FOLDERS` にテスト用 `sample_docs` を指定して起動し、インデックス構築が完了することを確認しました（ログ出力確認）。 
- Playwright スクリプトで検索（`POST /api/search`）とカード展開による遅延取得（`GET /api/detail`）を自動操作し、両 API が 200 を返し詳細が表示されることを確認してスクリーンショットを取得しました。 
- 変更に対するユニットテストは追加しておらず、実行したのは上記の手動/自動 E2E 操作のみで成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696585a693a4833082f7def6028b783c)