### PR TITLE
アクティブクライアント数に基づく動的ワーカー割当（heartbeat）を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 変更履歴
 
-System Version: 1.1.7
+System Version: 1.1.8
+
+## 1.1.8
+
+- 2026-01-12: 機能追加: アクティブクライアント数に応じた動的ワーカー割当と心拍を実装（issue #19 対応）。
+  - `/api/heartbeat` を追加し、TTL 内の心拍数から active_clients を算出
+  - heartbeats に基づき `workers_per_request` を動的に計算（ワーカー予算を分配）
+  - UI から 40 秒間隔の心拍送信とユーザー操作時の即時送信を追加
 
 ## 1.1.7
 


### PR DESCRIPTION
### Motivation
- 検索リクエスト数のスパイクに引っ張られない安定したワーカー割当を、接続中のアクティブクライアント数に基づいて実現するため。 
- クライアント側の定期的な心拍（heartbeat）で「実際に利用中のクライアント数」を推定して割当に反映するため。 
- TTL を設けることで短時間の離席を許容しつつ安定した集計（デフォルト `90` 秒）を行うため。 
- UI 側の軽微な改修で心拍を送信し、検索実行前に利用状態を即時反映できるようにするため。 

### Description
- サーバーに `HeartbeatRequest` モデルと `POST /api/heartbeat` エンドポイントを追加し、`active_clients` を `active_clients: Dict[str, float]` と `active_clients_lock` で管理する実装を追加しました。 
- TTL 設定は `HEARTBEAT_TTL_SEC`（デフォルト `90` 秒）で制御し、`register_active_client` と `_prune_active_clients` によって有効カウントを算出します。 
- ワーカー割当ロジックを `total_worker_budget` と `per_request_workers` に実装し、`SEARCH_CPU_BUDGET` または `search_worker_count * search_concurrency` を全体予算として `workers_per_request = clamp(floor(total_budget / max(1, active_clients)), 1, search_worker_count)` 相当で算出して `/api/search` と `/api/export` で利用するように統合しました。 
- フロントエンド (`static/app.js`) に定期心拍（40秒）、ユーザー操作／可視化復帰時の即時送信、検索前の即時送信を追加し、クライアント識別は `localStorage` の `ftsHeartbeatClientId` で保持します。 
- `SYSTEM_VERSION` を `1.1.8` に更新し、`CHANGELOG.md` を追記しました。 

### Testing
- 自動化されたユニット/統合テストは実行していません。 
- 既存のアプリ起動フローや検索経路に統合するための単体ログ出力を追加し、動作観察のためのログ（`active_clients` 表示）を出力するようにしましたが自動テストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965afb366888330ba6e347583cafa24)